### PR TITLE
Updated the Date strings in activities to use a timestamp.

### DIFF
--- a/screens/Contact/ContactDetailScreen.js
+++ b/screens/Contact/ContactDetailScreen.js
@@ -1119,6 +1119,28 @@ class ContactDetailScreen extends React.Component {
     return `${monthNames[newDate.getMonth()]} ${newDate.getDate()}, ${age} ${strTime}`;
   };
 
+  formatActivityDate = (comment) => {
+    baptismDateRegex = /\{(\d+)\}+/;
+
+    if (baptismDateRegex.test(comment)) {
+      comment = comment.replace(baptismDateRegex, this.formatTimestampToDate);
+    }
+    return comment;
+  };
+
+  formatTimestampToDate = (match, timestamp) => {
+    let langcode = this.props.userData.locale.substring(0, 2);
+    if (langcode === 'fa') {
+      //This is a check so that we use the gergorian (Western) calendar if the users locale is Farsi. This is the calendar used primarily by Farsi speakers outside of Iran, and is easily understood by those inside.
+      langcode = `${langcode}-u-ca-gregory`;
+    }
+    console.log(langcode);
+    const options = { year: 'numeric', month: 'long', day: 'numeric' };
+    let formattedDate = new Intl.DateTimeFormat(langcode, options).format(timestamp * 1000);
+
+    return formattedDate;
+  };
+
   setComment = (value) => {
     this.setState({
       comment: value,
@@ -3652,7 +3674,7 @@ class ContactDetailScreen extends React.Component {
           ]}>
           {Object.prototype.hasOwnProperty.call(commentOrActivity, 'content')
             ? commentOrActivity.content
-            : commentOrActivity.object_note}
+            : this.formatActivityDate(commentOrActivity.object_note)}
         </Text>
       </View>
     </View>

--- a/screens/Group/GroupDetailScreen.js
+++ b/screens/Group/GroupDetailScreen.js
@@ -1234,7 +1234,7 @@ class GroupDetailScreen extends React.Component {
           }>
           {Object.prototype.hasOwnProperty.call(commentOrActivity, 'content')
             ? commentOrActivity.content
-            : commentOrActivity.object_note}
+            : this.formatActivityDate(commentOrActivity.object_note)}
         </Text>
       </View>
     </View>
@@ -1644,6 +1644,28 @@ class GroupDetailScreen extends React.Component {
     minutes = minutes < 10 ? `0${minutes}` : minutes;
     const strTime = `${hours}:${minutes} ${ampm}`;
     return `${monthNames[newDate.getMonth()]} ${newDate.getDate()}, ${age} ${strTime}`;
+  };
+
+  formatActivityDate = (comment) => {
+    baptismDateRegex = /\{(\d+)\}+/;
+
+    if (baptismDateRegex.test(comment)) {
+      comment = comment.replace(baptismDateRegex, this.formatTimestampToDate);
+    }
+    return comment;
+  };
+
+  formatTimestampToDate = (match, timestamp) => {
+    let langcode = this.props.userData.locale.substring(0, 2);
+    if (langcode === 'fa') {
+      //This is a check so that we use the gergorian (Western) calendar if the users locale is Farsi. This is the calendar used primarily by Farsi speakers outside of Iran, and is easily understood by those inside.
+      langcode = `${langcode}-u-ca-gregory`;
+    }
+    console.log(langcode);
+    const options = { year: 'numeric', month: 'long', day: 'numeric' };
+    let formattedDate = new Intl.DateTimeFormat(langcode, options).format(timestamp * 1000);
+
+    return formattedDate;
   };
 
   onSaveComment = () => {


### PR DESCRIPTION
To allow for a users locale to be different from the DT instance locale, we need to get a timestamp from the server and compile the date string based on the users locale. To do this in the main DT theme I made some changes in https://github.com/DiscipleTools/disciple-tools-theme/pull/925 to change the strings we save for Baptism date and Group start/end dates to include a time stamp wrapped in curly brackets. Then in JS locally we replace the timestamp with a formatted date string in the users locale.