### PR TITLE
resolves #411 - date and time separator on notifications page

### DIFF
--- a/screens/NotificationsScreen.js
+++ b/screens/NotificationsScreen.js
@@ -333,7 +333,7 @@ class NotificationsScreen extends React.Component {
             <Text
               style={[styles.prettyTime, this.props.isRTL ? { textAlign: 'left', flex: 1 } : {}]}>
               {moment(notification.date_notified).fromNow() +
-                ' | ' +
+                ' ~ ' +
                 moment(notification.date_notified).format('L')}
             </Text>
           </View>


### PR DESCRIPTION
notifications screen: changed the separator from being | to ~